### PR TITLE
feat: 댓글 기본적인 CRUD 구현

### DIFF
--- a/src/main/java/dgu/edu/dnaapi/controller/NoticeCommentsController.java
+++ b/src/main/java/dgu/edu/dnaapi/controller/NoticeCommentsController.java
@@ -1,0 +1,71 @@
+package dgu.edu.dnaapi.controller;
+
+import dgu.edu.dnaapi.domain.dto.*;
+import dgu.edu.dnaapi.domain.response.*;
+import dgu.edu.dnaapi.service.NoticeCommentsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class NoticeCommentsController {
+
+    private final NoticeCommentsService noticeCommentsService;
+
+    @GetMapping("/comments/notices/{noticeId}")
+    public ResponseEntity<Message> findAllByNoticeId(@PathVariable Long noticeId) {
+        List<NoticeCommentsResponseDto> comments = noticeCommentsService.findAll(noticeId);
+
+        ListResponse listResponse = ListResponse.builder()
+                .list(comments)
+                .totalCount(comments.size())
+                .build();
+
+        Message message = Message.builder()
+                .data(listResponse)
+                .apiStatus(new ApiStatus(StatusEnum.OK, null))
+                .build();
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        return new ResponseEntity(message, httpHeaders, HttpStatus.OK);
+    }
+
+    // api spec에는 없는데 게시글 Id가 dto 안에 있어야함(또는 Path에 있어야 할 것 같음)
+    // url도 기존 spec에서 type으로 게시판 구분하던거 빼아함
+    @PostMapping("/comments")
+    public ResponseEntity<Message> save(@RequestBody NoticeCommentsSaveDto requestDto) {
+        Long savedId = noticeCommentsService.save(requestDto);
+        Message message = Message.builder()
+                .data(savedId)
+                .apiStatus(new ApiStatus(StatusEnum.OK, null))
+                .build();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        return new ResponseEntity(message, httpHeaders, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/comments")
+    public ResponseEntity<Message> delete(@RequestBody NoticeCommentsDeleteDto requestDto) {
+        Long deleteId = noticeCommentsService.delete(requestDto);
+        Message message = Message.builder()
+                .data(deleteId)
+                .apiStatus(new ApiStatus(StatusEnum.OK, null))
+                .build();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        return new ResponseEntity(message, httpHeaders, HttpStatus.OK);
+    }
+
+    @PutMapping("/comments")
+    public ResponseEntity<Message> update(@RequestBody NoticeCommentsUpdateDto requestDto) {
+        Long updateId = noticeCommentsService.update(requestDto);
+        Message message = Message.builder()
+                .data(updateId)
+                .apiStatus(new ApiStatus(StatusEnum.OK, null))
+                .build();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        return new ResponseEntity(message, httpHeaders, HttpStatus.OK);
+    }
+}

--- a/src/main/java/dgu/edu/dnaapi/controller/NoticesController.java
+++ b/src/main/java/dgu/edu/dnaapi/controller/NoticesController.java
@@ -1,8 +1,6 @@
 package dgu.edu.dnaapi.controller;
 
-import dgu.edu.dnaapi.domain.dto.NoticesResponseDto;
-import dgu.edu.dnaapi.domain.dto.NoticesSaveRequestDto;
-import dgu.edu.dnaapi.domain.dto.NoticesUpdateRequestDto;
+import dgu.edu.dnaapi.domain.dto.*;
 import dgu.edu.dnaapi.domain.response.*;
 import dgu.edu.dnaapi.service.NoticesService;
 import lombok.RequiredArgsConstructor;
@@ -40,17 +38,6 @@ public class NoticesController {
         return new ResponseEntity(message, httpHeaders, HttpStatus.OK);
     }
 
-    @GetMapping("/notices/{id}")
-    public ResponseEntity<Message> findById(@PathVariable Long id) {
-        NoticesResponseDto responseDto = noticesService.findById(id);
-        Message message = Message.builder()
-                .data(responseDto)
-                .apiStatus(new ApiStatus(StatusEnum.OK, null))
-                .build();
-        HttpHeaders httpHeaders = new HttpHeaders();
-        return new ResponseEntity(message, httpHeaders, HttpStatus.OK);
-    }
-
     @GetMapping("/notices")
     public ResponseEntity<Message> findAll() {
         List<NoticesResponseDto> noticesList = noticesService.findAll();
@@ -67,8 +54,21 @@ public class NoticesController {
         return new ResponseEntity(message, httpHeaders, HttpStatus.OK);
     }
 
+    @GetMapping("/notices/{id}")
+    public ResponseEntity<Message> findById(@PathVariable Long id) {
+        NoticesResponseDto responseDto = noticesService.findById(id);
+
+        Message message = Message.builder()
+                .data(responseDto)
+                .apiStatus(new ApiStatus(StatusEnum.OK, null))
+                .build();
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        return new ResponseEntity(message, httpHeaders, HttpStatus.OK);
+    }
+
     @DeleteMapping("/notices")
-    public ResponseEntity<Message> delete(@RequestBody NoticesUpdateRequestDto requestDto) {
+    public ResponseEntity<Message> delete(@RequestBody NoticesDeleteRequestDto requestDto) {
         Long deleteId = noticesService.delete(requestDto);
         Message message = Message.builder()
                 .data(deleteId)

--- a/src/main/java/dgu/edu/dnaapi/domain/NoticeComments.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/NoticeComments.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Comments extends BaseEntity {
+public class NoticeComments extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,35 +21,49 @@ public class Comments extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parentId")
-    private Comments parent;
+    private NoticeComments parent;
+
+    private Long parentCommentId;
 
     @OneToMany(mappedBy = "parent")
-    private List<Comments> childList;
+    private List<NoticeComments> childList;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "noticeId", nullable = false)
     private Notices notice;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId", nullable = false)
+    @JoinColumn(name = "userId", nullable = true) // todo: 고민 nullable true or false?
     private User author;
+
+    private String username;
 
     private int likeCount;
 
     @Builder
-    public Comments(Notices notice, User author, String content, Comments parent, int likeCount) {
+    public NoticeComments(Notices notice, Long noticeId, User author, String content, NoticeComments parent, Long parentCommentId, int likeCount) {
         this.notice = notice;
         this.author = author;
         this.content = content;
         this.parent = parent;
+        this.parentCommentId = parentCommentId;
         this.likeCount = likeCount;
     }
 
-    public void addChild(Comments child){
+    public void addChild(NoticeComments child){
         childList.add(child);
     }
 
     public void update(String content) {
         this.content = content;
     }
+
+    public void registerNotice(Notices notice) {
+        this.notice = notice;
+    }
+    public void registerParent(NoticeComments parent) {
+        this.parent = parent;
+    }
+
+
 }

--- a/src/main/java/dgu/edu/dnaapi/domain/Notices.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/Notices.java
@@ -26,7 +26,7 @@ public class Notices extends BaseEntity {
     private User author;
 
     @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<Comments> comments;
+    private List<NoticeComments> comments;
 
     @Builder
     public Notices(String title, String content, User author) {

--- a/src/main/java/dgu/edu/dnaapi/domain/dto/NoticeCommentsDeleteDto.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/dto/NoticeCommentsDeleteDto.java
@@ -1,0 +1,16 @@
+package dgu.edu.dnaapi.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NoticeCommentsDeleteDto {
+    private Long commentId;
+
+    @Builder
+    public NoticeCommentsDeleteDto(Long commentId) {
+        this.commentId = commentId;
+    }
+}

--- a/src/main/java/dgu/edu/dnaapi/domain/dto/NoticeCommentsResponseDto.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/dto/NoticeCommentsResponseDto.java
@@ -1,0 +1,47 @@
+package dgu.edu.dnaapi.domain.dto;
+
+import dgu.edu.dnaapi.domain.NoticeComments;
+import dgu.edu.dnaapi.domain.User;
+import dgu.edu.dnaapi.domain.response.ListResponse;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class NoticeCommentsResponseDto {
+    private Long commentId;
+    private String content;
+    private String author;
+    private Long authorId;
+    private Long parentId;
+    private String modifiedAt;
+    private ListResponse childrenComments;
+
+    public NoticeCommentsResponseDto(NoticeComments entity) {
+        this.commentId = entity.getCommentId();
+        this.content = entity.getContent();
+        // todo 나중에 user 매핑되도록 (or nullable -> Optional)
+        User user = entity.getAuthor();
+        if  (author != null) {
+            this.author = user.getUsername();
+            this.authorId = user.getId();
+        }
+        // todo 나중에 Optional 처리?
+        NoticeComments parent = entity.getParent();
+        if (parent != null)
+            this.parentId = parent.getCommentId();
+
+        this.modifiedAt = entity.getLastModifiedDate().toString();
+
+        if(!entity.getChildList().isEmpty()) {
+            List<NoticeCommentsResponseDto> children = entity.getChildList()
+                    .stream().map(NoticeCommentsResponseDto::new).collect(Collectors.toList());
+            this.childrenComments = ListResponse.builder()
+                    .list(children)
+                    .totalCount(children.size())
+                    .build();
+        }
+
+    }
+}

--- a/src/main/java/dgu/edu/dnaapi/domain/dto/NoticeCommentsSaveDto.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/dto/NoticeCommentsSaveDto.java
@@ -1,0 +1,31 @@
+package dgu.edu.dnaapi.domain.dto;
+
+import dgu.edu.dnaapi.domain.NoticeComments;
+import dgu.edu.dnaapi.domain.Notices;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NoticeCommentsSaveDto {
+    private String content;
+    private Long noticeId;
+    private Long parentCommentId;
+
+    @Builder
+    public NoticeCommentsSaveDto(String content, Long noticeId, Long parentCommentId) {
+        this.content = content;
+        this.noticeId = noticeId;
+        this.parentCommentId = parentCommentId;
+    }
+
+    public NoticeComments toEntity() {
+        NoticeComments comments = NoticeComments.builder()
+                .content(content)
+                .parentCommentId(parentCommentId)
+                .build();
+
+        return comments;
+    }
+}

--- a/src/main/java/dgu/edu/dnaapi/domain/dto/NoticeCommentsUpdateDto.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/dto/NoticeCommentsUpdateDto.java
@@ -1,0 +1,18 @@
+package dgu.edu.dnaapi.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NoticeCommentsUpdateDto {
+    private Long commentId;
+    private String content;
+
+    @Builder
+    public NoticeCommentsUpdateDto(Long commentId, String content) {
+        this.commentId = commentId;
+        this.content = content;
+    }
+}

--- a/src/main/java/dgu/edu/dnaapi/domain/dto/NoticesResponseDto.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/dto/NoticesResponseDto.java
@@ -1,21 +1,34 @@
 package dgu.edu.dnaapi.domain.dto;
 
+import dgu.edu.dnaapi.domain.NoticeComments;
 import dgu.edu.dnaapi.domain.Notices;
-import dgu.edu.dnaapi.domain.User;
+import dgu.edu.dnaapi.domain.response.ListResponse;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class NoticesResponseDto {
+
     private Long noticeId;
     private String title;
     private String content;
-    private User author;
+    private String author;
+    private Long authorId;
+    private int commentCount;
+    private String modifiedAt;
 
     public NoticesResponseDto(Notices entity) {
         this.noticeId = entity.getNoticeId();
         this.title = entity.getTitle();
         this.content = entity.getContent();
-        this.author = entity.getAuthor();
+//        this.author = entity.getAuthor().getUsername();
+//        this.authorId = entity.getAuthor().getId();
+        this.commentCount = entity.getComments().size();
+        this.modifiedAt = entity.getLastModifiedDate().toString();
     }
 
 }

--- a/src/main/java/dgu/edu/dnaapi/repository/NoticesCommentsRepository.java
+++ b/src/main/java/dgu/edu/dnaapi/repository/NoticesCommentsRepository.java
@@ -1,0 +1,7 @@
+package dgu.edu.dnaapi.repository;
+
+import dgu.edu.dnaapi.domain.NoticeComments;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticesCommentsRepository  extends JpaRepository<NoticeComments, Long> {
+}

--- a/src/main/java/dgu/edu/dnaapi/service/NoticeCommentsService.java
+++ b/src/main/java/dgu/edu/dnaapi/service/NoticeCommentsService.java
@@ -1,0 +1,72 @@
+package dgu.edu.dnaapi.service;
+
+import dgu.edu.dnaapi.domain.NoticeComments;
+import dgu.edu.dnaapi.domain.Notices;
+import dgu.edu.dnaapi.domain.dto.*;
+import dgu.edu.dnaapi.repository.NoticesCommentsRepository;
+import dgu.edu.dnaapi.repository.NoticesRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class NoticeCommentsService {
+    private final NoticesRepository noticesRepository;
+    private final NoticesCommentsRepository noticesCommentsRepository;
+
+    @Transactional
+    public Long save(NoticeCommentsSaveDto requestDto) {
+        NoticeComments comment = requestDto.toEntity();
+        Long noticeId = requestDto.getNoticeId();
+        Long parentCommentId = requestDto.getParentCommentId();
+
+        Notices notice = noticesRepository.findById(noticeId).orElseThrow(
+                () -> new IllegalArgumentException("해당 글이 없습니다. id=" + noticeId));
+        comment.registerNotice(notice);
+
+        if(parentCommentId != null) {
+            NoticeComments parent = noticesCommentsRepository.findById(parentCommentId).orElseThrow(
+                    () -> new IllegalArgumentException("해당 댓글이 없습니다. id=" + parentCommentId));
+            comment.registerParent(parent);
+            parent.addChild(comment);
+        }
+
+        return noticesCommentsRepository.save(comment).getCommentId();
+    }
+
+    @Transactional
+    public Long update(NoticeCommentsUpdateDto requestDto) {
+        Long id = requestDto.getCommentId();
+        NoticeComments notices = noticesCommentsRepository.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("해당 댓글이 없습니다. id=" + id));
+        notices.update(requestDto.getContent());
+        return id;
+    }
+
+    public NoticeCommentsResponseDto findById(Long id) {
+        NoticeComments entity = noticesCommentsRepository.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("해당 게시글이 없습니다. id=" + id));
+        return new NoticeCommentsResponseDto(entity);
+    }
+
+    @Transactional
+    public Long delete(NoticeCommentsDeleteDto requestDto) {
+        // todo 나중에 대댓글 삭제 조건 처리 등 추가 해야함
+        Long deleteId = requestDto.getCommentId();
+        noticesCommentsRepository.deleteById(deleteId);
+
+        return deleteId;
+    }
+
+    public List<NoticeCommentsResponseDto> findAll(Long noticeId) {
+        List<NoticeComments> commentsList = noticesCommentsRepository.findAll();
+        return commentsList.stream()
+                .filter(c -> c.getNotice().getNoticeId().equals(noticeId))
+                .map(NoticeCommentsResponseDto::new).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/dgu/edu/dnaapi/service/NoticesService.java
+++ b/src/main/java/dgu/edu/dnaapi/service/NoticesService.java
@@ -1,12 +1,12 @@
 package dgu.edu.dnaapi.service;
 
 import dgu.edu.dnaapi.domain.Notices;
+import dgu.edu.dnaapi.domain.dto.NoticesDeleteRequestDto;
 import dgu.edu.dnaapi.domain.dto.NoticesResponseDto;
 import dgu.edu.dnaapi.domain.dto.NoticesSaveRequestDto;
 import dgu.edu.dnaapi.domain.dto.NoticesUpdateRequestDto;
 import dgu.edu.dnaapi.repository.NoticesRepository;
 import lombok.RequiredArgsConstructor;
-import org.aspectj.weaver.ast.Not;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,7 +40,7 @@ public class NoticesService {
     }
 
     @Transactional
-    public Long delete(NoticesUpdateRequestDto requestDto) {
+    public Long delete(NoticesDeleteRequestDto requestDto) {
         Long deleteId = requestDto.getNoticeId();
         noticesRepository.deleteById(deleteId);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
     hibernate:
-      ddl-auto: create #create update none
+      ddl-auto: update #create update none
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: true

--- a/src/test/java/dgu/edu/dnaapi/NoticesRepositoryTest.java
+++ b/src/test/java/dgu/edu/dnaapi/NoticesRepositoryTest.java
@@ -48,7 +48,7 @@ public class NoticesRepositoryTest {
         noticesRepository.save(Notices.builder()
                 .title(title)
                 .content(content)
-                .author("test@test.com")
+//                .author("test@test.com")
                 .build());
 
         List<Notices> noticeList = noticesRepository.findAll();
@@ -66,7 +66,6 @@ public class NoticesRepositoryTest {
         NoticesSaveRequestDto requestDto = NoticesSaveRequestDto.builder()
                 .title(title)
                 .content(content)
-                .author("author")
                 .build();
 
         String url = "http://localhost:" + port + "/boards/notices";
@@ -87,7 +86,7 @@ public class NoticesRepositoryTest {
         Notices savedNotices = noticesRepository.save(Notices.builder()
                 .title("ex-title")
                 .content("ex-content")
-                .author("km")
+//                .author("km")
                 .build());
 
         Long updateId = savedNotices.getNoticeId();
@@ -119,7 +118,7 @@ public class NoticesRepositoryTest {
         Notices savedNotices = noticesRepository.save(Notices.builder()
                 .title("ex-title")
                 .content("ex-content")
-                .author("km")
+//                .author("km")
                 .build());
 
         Long deleteId = savedNotices.getNoticeId();


### PR DESCRIPTION
### 댓글 기본적인 CRUD 구현
- 대댓글 기능 포함
- 아래 참고사항 보면 알 수 있듯 코드가 깔끔하지 않고 예외처리도 많이 빠진 느낌,,

### 참고사항
- 게시글과 댓글에서 작성자 정보는 제외하였음
> 작성자(User)의 nullable 여부 True or False인지 모르겠음. 이후 로그인 한 상태에서 작성하도록 하는거면 기능 추가 구현 필요할듯.
- 댓글 Depth 따로 처리하는 부분 아직 포함하지 않아서 계속 늘어남
- 대댓글 있는 댓글의 경우에도 고려하지 않고 삭제됨
- 다른 글의 댓글을 parentCommentId로 설정하면 안되도록 예외처리 필요함
- 게시글 목록 조회할 때 게시글 내용까지 전부 가져오는 문제(제목 및 기타 필요한 정보만 가져오도록 수정해야함)
- 좋아요 구현 아직 못함..