### PR TITLE
feat : 자유게시판 무한 스크롤링 No-Offset 구조로 구현, "제목, 작성자, 내용, 제목 및 내용" 검색 조건 기능 구현

### DIFF
--- a/src/main/java/dgu/edu/dnaapi/config/WebConfig.java
+++ b/src/main/java/dgu/edu/dnaapi/config/WebConfig.java
@@ -1,0 +1,15 @@
+package dgu.edu.dnaapi.config;
+
+import dgu.edu.dnaapi.util.StringToBoardSearchCriteriaConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new StringToBoardSearchCriteriaConverter());
+    }
+}

--- a/src/main/java/dgu/edu/dnaapi/domain/BoardSearchCriteria.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/BoardSearchCriteria.java
@@ -1,0 +1,18 @@
+package dgu.edu.dnaapi.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum BoardSearchCriteria {
+
+    TITLE("title"),
+    AUTHOR("author"),
+    CONTENT("content"),
+    TITLE_AND_CONTENT("titleAndContent");
+
+    private String searchCriteria;
+
+    BoardSearchCriteria(String searchCriteria) {
+        this.searchCriteria = searchCriteria;
+    }
+}

--- a/src/main/java/dgu/edu/dnaapi/domain/response/DnaStatusCode.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/response/DnaStatusCode.java
@@ -22,6 +22,7 @@ public enum DnaStatusCode {
     INVALID_INPUT(400, "N100", "Invalid input value, Please check your input and constraints"),
     INVALID_POST(404, "N101", "No post has that information, Please check your request"),
     INVALID_COMMENT(404, "N102", "No comment has that information, Please check your request"),
+    INVALID_SEARCH_OPTION(404, "N103", "Invalid search option, pleas check your search criteria or keywords"),
 
     /**
      * Auth Exception

--- a/src/main/java/dgu/edu/dnaapi/domain/response/ListResponse.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/response/ListResponse.java
@@ -7,10 +7,13 @@ import lombok.Getter;
 public class ListResponse {
     private Object list;
     private int totalCount;
+    private boolean hasNext;
 
+    // Todo : totalCount 삭제예정 -> Forum 개발 Legacy 때문에 남겨둠
     @Builder
-    public ListResponse(Object list, int totalCount) {
+    public ListResponse(Object list, int totalCount, boolean hasNext) {
         this.list = list;
         this.totalCount = totalCount;
+        this.hasNext = hasNext;
     }
 }

--- a/src/main/java/dgu/edu/dnaapi/repository/NoticesRepository.java
+++ b/src/main/java/dgu/edu/dnaapi/repository/NoticesRepository.java
@@ -1,8 +1,13 @@
 package dgu.edu.dnaapi.repository;
 
 import dgu.edu.dnaapi.domain.Notices;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,4 +16,56 @@ public interface NoticesRepository extends JpaRepository<Notices, Long> {
     @Override
     @EntityGraph(attributePaths = {"author"}, type = EntityGraph.EntityGraphType.FETCH)
     List<Notices> findAll();
+
+    @Query("SELECT n " +
+            "FROM Notices n " +
+            "WHERE n.noticeId <= :start " +
+            "ORDER BY n.noticeId desc")
+    Slice<Notices> findAllByNoticeId(@Param("start") Long start, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"author"}, type = EntityGraph.EntityGraphType.FETCH)
+    Slice<Notices> findSliceBy(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"author"}, type = EntityGraph.EntityGraphType.FETCH)
+    Slice<Notices> findAllByTitleContaining(String title, Pageable pageable);
+
+    List<Notices> findAllByTitleContaining(String title);
+
+    @Query("SELECT n " +
+            "FROM Notices n " +
+            "WHERE n.noticeId <= :start " +
+            "and n.title LIKE %:keyword% " +
+            "ORDER BY n.noticeId desc")
+    Slice<Notices> findAllByTitleContaining(@Param("start") Long start, @Param("keyword")String keyword, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"author"}, type = EntityGraph.EntityGraphType.FETCH)
+    Slice<Notices> findAllByContentContaining(String content, Pageable pageable);
+
+    @Query("SELECT n " +
+            "FROM Notices n " +
+            "WHERE n.noticeId <= :start " +
+            "and n.content LIKE %:keyword% " +
+            "ORDER BY n.noticeId desc")
+    Slice<Notices> findAllByContentContaining(@Param("start") Long start, @Param("keyword")String keyword, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"author"}, type = EntityGraph.EntityGraphType.FETCH)
+    Slice<Notices> findAllByAuthor_UserNameContaining(String author, Pageable pageable);
+
+    @Query("SELECT n " +
+            "FROM Notices n " +
+            "WHERE n.noticeId <= :start " +
+            "and n.author.userName LIKE %:keyword% " +
+            "ORDER BY n.noticeId desc")
+    Slice<Notices> findAllByAuthorContaining(@Param("start") Long start, @Param("keyword")String keyword, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"author"}, type = EntityGraph.EntityGraphType.FETCH)
+    Slice<Notices> findAllByTitleContainingOrContentContaining(String title,String content, Pageable pageable);
+
+    @Query("SELECT n " +
+            "FROM Notices n " +
+            "WHERE n.noticeId <= :start " +
+            "and (n.title LIKE %:keyword% " +
+            "or n.content LIKE %:keyword%) " +
+            "ORDER BY n.noticeId desc")
+    Slice<Notices> findAllByTitleContainingOrContentContaining(@Param("start") Long start, @Param("keyword")String keyword, Pageable pageable);
 }

--- a/src/main/java/dgu/edu/dnaapi/util/StringToBoardSearchCriteriaConverter.java
+++ b/src/main/java/dgu/edu/dnaapi/util/StringToBoardSearchCriteriaConverter.java
@@ -1,0 +1,21 @@
+package dgu.edu.dnaapi.util;
+
+import dgu.edu.dnaapi.domain.BoardSearchCriteria;
+import dgu.edu.dnaapi.exception.DNACustomException;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.ConverterFactory;
+
+import static dgu.edu.dnaapi.domain.response.DnaStatusCode.INVALID_SEARCH_OPTION;
+
+public class StringToBoardSearchCriteriaConverter implements Converter<String, BoardSearchCriteria> {
+
+    @Override
+    public BoardSearchCriteria convert(String source) {
+        for (BoardSearchCriteria value : BoardSearchCriteria.values()) {
+            if (value.getSearchCriteria().equals(source))
+                return value;
+        }
+        System.out.println("source = " + source);
+        throw new DNACustomException("Invalid Search Option", INVALID_SEARCH_OPTION);
+    }
+}


### PR DESCRIPTION
## 개요
자유게시판 무한 스크롤링 No-Offset 구조로 구현, "제목, 작성자, 내용, 제목 및 내용" 검색 조건 기능 구현

## 작업사항
*  자유게시판 무한 스크로링 기능 구현
* "제목, 작성자, 내용, 제목 및 내용" 검색 조건 기능 구현

## 향후 작업
* 댓글에 대해서도 동일한 작업 진행 예정
* Forum에도 동일한 작업 진행 예정
* 댓글, 좋아요 개수 정보 가져오도록 구현 예정

## 테스트
Local 테스트 완료 

## 메모
API Specification ()을 참조 부탁드립니다. 구현상 조금 변경되었습니다.
(https://profuse-cloud-26a.notion.site/DNA-Project-Backend-24c5821eef3d4885aa887dceeb1ba857)
### 주요 변경사항
* criteria ->  {title, author, content, titleAndContent} 4개 중 하나로 요청
* 현재 default page size = 13 (13개의 게시글 정보를 한번의 요청에 가져옴)
*  기존의 "totalCount" 정보대신 hasNext : boolean(true or false) 정보를 주도록 변경
*  곧 totalCount 삭제예정
```
# GET /boards/notices?start=3&criteria=title&keyword=zz
/*
*     criteria -> {title, author, content, titleAndContent} 4개 중 하나
*     현재 default page size = 13 (13개의 게시글 정보를 한번의 요청에 가져옴)
*     기존의 "totalCount" 정보대신 hasNext : boolean(true or false) 정보를 줌
*     곧 totalCount 삭제예정
*/
{
    "data":{
        "list":[{
                    "title":"",
                    "commentCount":16,
                    "author":"",
                    "level":21,
                    "modifiedAt":"2016-11-21T12:12...",
                    "likeCount":100
                    }],
        "totalCount":100,
        "hasNext": true,
    },
    "apiStatus":{
        "errorMessage":"",
        "errorCode":"N200"
    }
}
``` 