### PR TITLE
feat : 회원가입, 로그인, 로그아웃, 유저 승인 기능 수정 및 개발

### DIFF
--- a/src/main/java/dgu/edu/dnaapi/domain/User.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/User.java
@@ -22,6 +22,7 @@ public class User extends BaseEntity{
     private String password;
     private String email;
     private int level;
+    private String studentId;
 
     @Enumerated(EnumType.STRING)
     private UserRole role;
@@ -30,7 +31,7 @@ public class User extends BaseEntity{
     private String providerId;
 
     @Builder
-    public User(Long id, String userName, String password, String email, int level, UserRole role, String provider, String providerId) {
+    public User(Long id, String userName, String password, String email, int level, UserRole role, String provider, String providerId, String studentId) {
         this.id = id;
         this.userName = userName;
         this.password = password;
@@ -39,5 +40,10 @@ public class User extends BaseEntity{
         this.role = role;
         this.provider = provider;
         this.providerId = providerId;
+        this.studentId = studentId;
+    }
+
+    public void authorizeUser() {
+        this.role = UserRole.USER_ROLE;
     }
 }

--- a/src/main/java/dgu/edu/dnaapi/domain/UserRole.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/UserRole.java
@@ -1,5 +1,5 @@
 package dgu.edu.dnaapi.domain;
 
 public enum UserRole {
-    USER_ROLE, MANAGER_ROLE
+    USER_ROLE, ADMIN_ROLE, UNVERIFIED_USER_ROLE
 }

--- a/src/main/java/dgu/edu/dnaapi/domain/dto/auth/SignUpDto.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/dto/auth/SignUpDto.java
@@ -1,6 +1,7 @@
 package dgu.edu.dnaapi.domain.dto.auth;
 
 import dgu.edu.dnaapi.domain.User;
+import dgu.edu.dnaapi.domain.UserRole;
 import lombok.*;
 
 
@@ -27,6 +28,8 @@ public class SignUpDto {
                 .email(email)
                 .password(password)
                 .level(Integer.parseInt(studentId.substring(2,4)))
+                .studentId(studentId)
+                .role(UserRole.UNVERIFIED_USER_ROLE)
                 .build();
     }
 }

--- a/src/main/java/dgu/edu/dnaapi/domain/dto/auth/UnverifiedUser.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/dto/auth/UnverifiedUser.java
@@ -1,0 +1,21 @@
+package dgu.edu.dnaapi.domain.dto.auth;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+@Data
+public class UnverifiedUser {
+
+    private String email;
+    private String username;
+    private Long userId;
+    private String studentId;
+
+    @QueryProjection
+    public UnverifiedUser(String email, String username, Long userId, String studentId) {
+        this.email = email;
+        this.username = username;
+        this.userId = userId;
+        this.studentId = studentId;
+    }
+}

--- a/src/main/java/dgu/edu/dnaapi/domain/response/DnaStatusCode.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/response/DnaStatusCode.java
@@ -38,6 +38,9 @@ public enum DnaStatusCode {
     INVALID_AUTHOR(403, "N203", "Only Author can do request work, Please Check your authority"),
     INVALID_USER(403, "N204", "No user has that information, Please check your information"),
     INVALID_OAUTH_INFO(403, "N205", "Invalid OAuth"),
+    UNVERIFIED_USER(403, "N206", "INVALID USER, Only authorized users can log in"),
+    UNAUTHORIZED_REQUEST(403, "N207", "Unauthorized request, Only ADMIN Can do it"),
+
 
     /**
      * Token Exception

--- a/src/main/java/dgu/edu/dnaapi/repository/UserRepository.java
+++ b/src/main/java/dgu/edu/dnaapi/repository/UserRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
     public User findByUserName(String userName);
 

--- a/src/main/java/dgu/edu/dnaapi/repository/UserRepositoryCustom.java
+++ b/src/main/java/dgu/edu/dnaapi/repository/UserRepositoryCustom.java
@@ -1,0 +1,10 @@
+package dgu.edu.dnaapi.repository;
+
+import dgu.edu.dnaapi.domain.dto.auth.UnverifiedUser;
+
+import java.util.List;
+
+public interface UserRepositoryCustom {
+
+    List<UnverifiedUser> findAllUnverifiedUser();
+}

--- a/src/main/java/dgu/edu/dnaapi/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/dgu/edu/dnaapi/repository/UserRepositoryCustomImpl.java
@@ -1,0 +1,34 @@
+package dgu.edu.dnaapi.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dgu.edu.dnaapi.domain.UserRole;
+import dgu.edu.dnaapi.domain.dto.auth.QUnverifiedUser;
+import dgu.edu.dnaapi.domain.dto.auth.UnverifiedUser;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static dgu.edu.dnaapi.domain.QUser.user;
+
+public class UserRepositoryCustomImpl implements UserRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    public UserRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+
+    @Override
+    public List<UnverifiedUser> findAllUnverifiedUser() {
+        return queryFactory
+                .select(new QUnverifiedUser(
+                        user.email,
+                        user.userName,
+                        user.id,
+                        user.studentId))
+                .from(user)
+                .where(user.role.eq(UserRole.UNVERIFIED_USER_ROLE))
+                .fetch();
+    }
+}

--- a/src/main/java/dgu/edu/dnaapi/service/UserService.java
+++ b/src/main/java/dgu/edu/dnaapi/service/UserService.java
@@ -3,6 +3,7 @@ package dgu.edu.dnaapi.service;
 import dgu.edu.dnaapi.config.CustomBCryptPasswordEncoder;
 import dgu.edu.dnaapi.domain.User;
 import dgu.edu.dnaapi.domain.dto.auth.LoginRequestDto;
+import dgu.edu.dnaapi.domain.dto.auth.UnverifiedUser;
 import dgu.edu.dnaapi.domain.response.DnaStatusCode;
 import dgu.edu.dnaapi.exception.DNACustomException;
 import dgu.edu.dnaapi.repository.UserRepository;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -53,5 +55,15 @@ public class UserService {
     public User getUserByUserId(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(()-> new DNACustomException("해당 회원이 없습니다.", DnaStatusCode.INVALID_USER));
+    }
+
+    public List<UnverifiedUser> getUnverifiedUserList() {
+        return userRepository.findAllUnverifiedUser();
+    }
+
+    @Transactional
+    public long authorizeUser(User user) {
+        user.authorizeUser();
+        return user.getId();
     }
 }


### PR DESCRIPTION
## 개요
회원가입, 로그인, 로그아웃, 유저 승인 기능 수정 및 개발

## 작업사항
* 회원가입시 승인받도록 role 변경
* 관리자가 승인할 수 있도록 API 개발
* 로그아웃 개발

## 메모
API 확인해주세요
(https://profuse-cloud-26a.notion.site/DNA-API-Docs-a6aa08caa22c4206993e9cb28e6d7b8d?pvs=4)
```java
#GET auth/unverifiedUsers
response:
{
	"data": [
        {
            "email": "h@naver.com",
            "username": "하이요",
            "userId": 4,
            "studentId": "2021112134"
        },
        {
            "email": "h3@naver.com",
            "username": "드나왕",
            "userId": 5,
            "studentId": "2021112134"
        }
    ]
}

#POST auth/unverifiedUsers/{userId}
승인할 user의 userId
POST 요청시 ADMIN 계정의 accessToken을 보내야함


#POST auth/admin/signUp
임시로 만든 ADMIN 계정 회원가입
{
    "email":"",
    "username":"",
    "password":"",
    "studentId":""
}
``` 