### PR TITLE
Feature/albumPost refactor : AlbumPost 이미지 업로드, 게시글 CRUD API 요구사항에 맞도록 수정 (CkEditor5)

### DIFF
--- a/src/main/java/dgu/edu/dnaapi/controller/albumPost/AlbumPostController.java
+++ b/src/main/java/dgu/edu/dnaapi/controller/albumPost/AlbumPostController.java
@@ -1,11 +1,11 @@
 package dgu.edu.dnaapi.controller.albumPost;
 
+import dgu.edu.dnaapi.annotation.JwtRequired;
 import dgu.edu.dnaapi.config.jwt.JwtProperties;
 import dgu.edu.dnaapi.controller.dto.PostSearchCondition;
 import dgu.edu.dnaapi.domain.User;
 import dgu.edu.dnaapi.domain.dto.albumPost.AlbumPostResponseDto;
 import dgu.edu.dnaapi.domain.dto.albumPost.AlbumPostSaveRequestDto;
-import dgu.edu.dnaapi.domain.dto.albumPost.AlbumPostUpdateRequestDto;
 
 import dgu.edu.dnaapi.domain.response.DnaStatusCode;
 import dgu.edu.dnaapi.domain.response.ListResponse;
@@ -15,6 +15,7 @@ import dgu.edu.dnaapi.exception.DNACustomException;
 import dgu.edu.dnaapi.service.TokenService;
 import dgu.edu.dnaapi.service.UserService;
 import dgu.edu.dnaapi.service.albumPost.AlbumPostService;
+import dgu.edu.dnaapi.service.albumPost.dto.AmazonS3ObjectInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -24,7 +25,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.util.List;
 
 import static org.springframework.util.StringUtils.hasText;
 
@@ -36,28 +36,43 @@ public class AlbumPostController {
     private final AlbumPostService albumPostService;
     private final UserService userService;
 
-    @PostMapping("/albumPosts")
-    private ResponseEntity<Message> save (
-            @RequestPart("albumPost") AlbumPostSaveRequestDto requestDto,
-            @RequestPart(value = "images", required = false) List<MultipartFile> albumPostImages,
-            HttpServletRequest request
-    ) throws IOException {
-        User findUser = getUserFromToken(request);
-
-        if(albumPostImages == null)
-            requestDto.setThumbnailImageIndex(null);
-        if(albumPostImages != null && requestDto.getThumbnailImageIndex() == null)
-            requestDto.setThumbnailImageIndex(0);
-
-        Long saveId = albumPostService.save(requestDto.toEntity(findUser), albumPostImages, requestDto.getThumbnailImageIndex());
-        return ResponseEntity.createSuccessResponseMessage(Message.createSuccessMessage(saveId));
-    }
+//    @PostMapping("/albumPosts/legacy")
+//    public ResponseEntity<Message> save_legacy (
+//            @RequestPart("albumPost") AlbumPostSaveRequestDto requestDto,
+//            @RequestPart(value = "images", required = false) List<MultipartFile> albumPostImages,
+//            HttpServletRequest request
+//    ) throws IOException {
+//        User findUser = getUserFromToken(request);
+//
+//        if(albumPostImages == null)
+//            requestDto.setThumbnailImageIndex(null);
+//        if(albumPostImages != null && requestDto.getThumbnailImageIndex() == null)
+//            requestDto.setThumbnailImageIndex(0);
+//
+//        Long saveId = albumPostService.save(requestDto.toEntity(findUser), albumPostImages, requestDto.getThumbnailImageIndex());
+//        return ResponseEntity.createSuccessResponseMessage(Message.createSuccessMessage(saveId));
+//    }
+//
+//    @PutMapping("/albumPosts/{albumPostId}/legacy")
+//    public ResponseEntity<Message> update_legacy(
+//            @RequestPart("albumPost") AlbumPostUpdateRequestDto requestDto,
+//            @RequestPart(value = "images", required = false) List<MultipartFile> albumPostImages,
+//            @PathVariable("albumPostId") Long albumPostId,
+//            HttpServletRequest request
+//    ) throws IOException {
+//        User findUser = getUserFromToken(request);
+//        Long updateId = albumPostService.update(requestDto, albumPostId, findUser, albumPostImages);
+//        Message message = Message.createSuccessMessage(updateId);
+//        return ResponseEntity.createSuccessResponseMessage(message);
+//    }
 
     private User getUserFromToken(HttpServletRequest request) {
         String authorizationHeader = request.getHeader(JwtProperties.HEADER_STRING);
         if(!hasText(authorizationHeader))
             throw new DNACustomException(DnaStatusCode.TOKEN_INVALID);
+        System.out.println("authorizationHeader = " + authorizationHeader);
         User findUser = userService.getUserByUserId(tokenService.getUserId(authorizationHeader));
+        System.out.println("findUser = " + findUser);
         return findUser;
     }
 
@@ -82,18 +97,7 @@ public class AlbumPostController {
         return ResponseEntity.createSuccessResponseMessage(message);
     }
 
-    @PutMapping("/albumPosts/{albumPostId}")
-    public ResponseEntity<Message> update(
-            @RequestPart("albumPost") AlbumPostUpdateRequestDto requestDto,
-            @RequestPart(value = "images", required = false) List<MultipartFile> albumPostImages,
-            @PathVariable("albumPostId") Long albumPostId,
-            HttpServletRequest request
-    ) throws IOException {
-        User findUser = getUserFromToken(request);
-        Long updateId = albumPostService.update(requestDto, albumPostId, findUser, albumPostImages);
-        Message message = Message.createSuccessMessage(updateId);
-        return ResponseEntity.createSuccessResponseMessage(message);
-    }
+
 
     @DeleteMapping("/albumPosts/{albumPostId}")
     public ResponseEntity<Message> delete(
@@ -106,4 +110,42 @@ public class AlbumPostController {
         return ResponseEntity.createSuccessResponseMessage(message);
     }
 
+    @PostMapping("/albumPosts/images")
+    public AlbumPostImageResponseDto  saveImages (
+            @RequestPart("file") MultipartFile albumPostImage,
+            HttpServletRequest request
+    ) throws IOException {
+        User findUser = getUserFromToken(request);
+        System.out.println("albumPostImage = " + albumPostImage);
+        System.out.println("findUser = " + findUser);
+        AmazonS3ObjectInfo amazonS3ObjectInfo = albumPostService.saveImage(albumPostImage);
+        AlbumPostImageResponseDto dto = new AlbumPostImageResponseDto.AlbumPostImageResponseDtoBuilder()
+                .url(amazonS3ObjectInfo.getImageURL())
+                .uploaded(true)
+                .build();
+        return dto;
+    }
+
+    @PostMapping("/albumPosts")
+    public ResponseEntity<Message> save (
+            @JwtRequired User user,
+            @RequestBody AlbumPostSaveRequestDto requestDto
+    ) {
+        System.out.println("user = " + user);
+        System.out.println("albumPostService = " + albumPostService);
+        System.out.println("requestDto = " + requestDto.getContent() + requestDto.getTitle());
+        Long saveId = albumPostService.savePost(requestDto.toEntity(user));
+        return ResponseEntity.createSuccessResponseMessage(Message.createSuccessMessage(saveId));
+    }
+
+    @PutMapping("/albumPosts/{albumPostId}")
+    public ResponseEntity<Message> update(
+            @JwtRequired User user,
+            @RequestBody AlbumPostSaveRequestDto requestDto,
+            @PathVariable("albumPostId") Long albumPostId
+    ) throws IOException {
+        Long updateId = albumPostService.updateAlbumPost(requestDto, albumPostId, user);
+        Message message = Message.createSuccessMessage(updateId);
+        return ResponseEntity.createSuccessResponseMessage(message);
+    }
 }

--- a/src/main/java/dgu/edu/dnaapi/controller/albumPost/AlbumPostImageResponseDto.java
+++ b/src/main/java/dgu/edu/dnaapi/controller/albumPost/AlbumPostImageResponseDto.java
@@ -1,0 +1,17 @@
+package dgu.edu.dnaapi.controller.albumPost;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class AlbumPostImageResponseDto {
+
+    private String url;
+    private Boolean uploaded;
+
+    @Builder
+    public AlbumPostImageResponseDto(String url, Boolean uploaded) {
+        this.url = url;
+        this.uploaded = uploaded;
+    }
+}

--- a/src/main/java/dgu/edu/dnaapi/domain/dto/albumPost/AlbumPostSaveRequestDto_LEGACY.java
+++ b/src/main/java/dgu/edu/dnaapi/domain/dto/albumPost/AlbumPostSaveRequestDto_LEGACY.java
@@ -12,17 +12,23 @@ import java.util.ArrayList;
 @NoArgsConstructor
 @Getter
 @Setter
-public class AlbumPostSaveRequestDto {
+public class AlbumPostSaveRequestDto_LEGACY {
 
     private String title;
     private String content;
-    private String thumbnailImage;
+    private Integer thumbnailImageIndex;
 
     @Builder
-    public AlbumPostSaveRequestDto(String title, String content, String thumbnailImage) {
+    public AlbumPostSaveRequestDto_LEGACY(String title, String content, Integer thumbnailImageIndex) {
         this.title = title;
         this.content = content;
-        this.thumbnailImage = thumbnailImage;
+        this.thumbnailImageIndex = thumbnailImageIndex;
+    }
+
+    @Builder
+    public AlbumPostSaveRequestDto_LEGACY(String title, String content) {
+        this.title = title;
+        this.content = content;
     }
 
     public AlbumPost toEntity(User user) {
@@ -30,7 +36,6 @@ public class AlbumPostSaveRequestDto {
                 .title(title)
                 .content(content)
                 .author(user)
-                .thumbnailImage(thumbnailImage)
                 .albumPostImages(new ArrayList<>())
                 .build();
     }

--- a/src/main/java/dgu/edu/dnaapi/repository/albumPost/AlbumPostRepositoryCustom.java
+++ b/src/main/java/dgu/edu/dnaapi/repository/albumPost/AlbumPostRepositoryCustom.java
@@ -14,4 +14,5 @@ public interface AlbumPostRepositoryCustom {
     List<AlbumPostMetaDataResponseDto> search(PostSearchCondition condition, Pageable pageable);
     Optional<AlbumPost> findWithAlbumPostCommentsByAlbumPostId(Long albumPostId);
     Long getAlbumPostCountByUserId(Long userId);
+    Optional<AlbumPost> findWithAuthorByAlbumPostId(Long albumPostId);
 }

--- a/src/main/java/dgu/edu/dnaapi/repository/albumPost/AlbumPostRepositoryCustomImpl.java
+++ b/src/main/java/dgu/edu/dnaapi/repository/albumPost/AlbumPostRepositoryCustomImpl.java
@@ -112,4 +112,13 @@ public class AlbumPostRepositoryCustomImpl implements AlbumPostRepositoryCustom 
                 .where(albumPost.author.id.eq(userId))
                 .fetchOne();
     }
+
+    @Override
+    public Optional<AlbumPost> findWithAuthorByAlbumPostId(Long albumPostId) {
+        return Optional.ofNullable(queryFactory
+                        .selectFrom(albumPost)
+                        .join(albumPost.author, user).fetchJoin()
+                        .where(albumPost.albumPostId.eq(albumPostId))
+                        .fetchOne());
+    }
 }

--- a/src/main/java/dgu/edu/dnaapi/service/albumPost/AlbumPostImageService.java
+++ b/src/main/java/dgu/edu/dnaapi/service/albumPost/AlbumPostImageService.java
@@ -1,5 +1,6 @@
 package dgu.edu.dnaapi.service.albumPost;
 
+import dgu.edu.dnaapi.service.albumPost.dto.AmazonS3ObjectInfo;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;

--- a/src/main/java/dgu/edu/dnaapi/service/albumPost/AmazonS3Service.java
+++ b/src/main/java/dgu/edu/dnaapi/service/albumPost/AmazonS3Service.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import dgu.edu.dnaapi.domain.response.DnaStatusCode;
 import dgu.edu.dnaapi.exception.DNACustomException;
+import dgu.edu.dnaapi.service.albumPost.dto.AmazonS3ObjectInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -39,7 +40,7 @@ public class AmazonS3Service implements AlbumPostImageService {
         try(InputStream inputStream = file.getInputStream()) {
             amazonS3Client.putObject(new PutObjectRequest(bucketName, fileName, inputStream, objectMetadata)
                     .withCannedAcl(CannedAccessControlList.PublicRead));
-            return new AmazonS3ObjectInfo(fileName,amazonS3Client.getUrl(bucketName, fileName).toString());
+            return new AmazonS3ObjectInfo(fileName, amazonS3Client.getUrl(bucketName, fileName).toString());
         } catch(IOException e) {
             throw new DNACustomException(DnaStatusCode.AMAZONS3_IO_EXCEPTION);
         }

--- a/src/main/java/dgu/edu/dnaapi/service/albumPost/dto/AmazonS3ObjectInfo.java
+++ b/src/main/java/dgu/edu/dnaapi/service/albumPost/dto/AmazonS3ObjectInfo.java
@@ -1,4 +1,4 @@
-package dgu.edu.dnaapi.service.albumPost;
+package dgu.edu.dnaapi.service.albumPost.dto;
 
 import lombok.Getter;
 

--- a/src/test/java/dgu/edu/dnaapi/DnaApiApplicationTests.java
+++ b/src/test/java/dgu/edu/dnaapi/DnaApiApplicationTests.java
@@ -1,13 +1,13 @@
-package dgu.edu.dnaapi;
-
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-
-@SpringBootTest
-class DnaApiApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
-
-}
+//package dgu.edu.dnaapi;
+//
+//import org.junit.jupiter.api.Test;
+//import org.springframework.boot.test.context.SpringBootTest;
+//
+//@SpringBootTest
+//class DnaApiApplicationTests {
+//
+//	@Test
+//	void contextLoads() {
+//	}
+//
+//}

--- a/src/test/java/dgu/edu/dnaapi/service/ForumPostCommentServiceTest.java
+++ b/src/test/java/dgu/edu/dnaapi/service/ForumPostCommentServiceTest.java
@@ -1,24 +1,24 @@
-package dgu.edu.dnaapi.service;
-
-import dgu.edu.dnaapi.repository.forumPost.ForumPostCommentRepository;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-
-import javax.persistence.EntityManager;
-
-@SpringBootTest
-@Transactional
-class ForumPostCommentServiceTest {
-
-    @Autowired
-    EntityManager em;
-
-    @Autowired
-    ForumPostCommentRepository forumPostCommentRepository;
-
-    @Test
-    void save() {
-    }
-}
+//package dgu.edu.dnaapi.service;
+//
+//import dgu.edu.dnaapi.repository.forumPost.ForumPostCommentRepository;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import javax.persistence.EntityManager;
+//
+//@SpringBootTest
+//@Transactional
+//class ForumPostCommentServiceTest {
+//
+//    @Autowired
+//    EntityManager em;
+//
+//    @Autowired
+//    ForumPostCommentRepository forumPostCommentRepository;
+//
+//    @Test
+//    void save() {
+//    }
+//}


### PR DESCRIPTION
## 개요
refactor : AlbumPost 이미지 업로드, 게시글 CRUD API 요구사항에 맞도록 수정 (CkEditor5)

## 작업사항
* AlbumPost 이미지 업로드
* AlbumPost 게시글 생성 CRUD

## 테스트
로컬, AWS 서버 확인

## 메모
```java
# POST /albumPosts/images
formData
key = "file" 로 이미지 보내기

# POST /albumPosts
{
    "title": "앨범게시글 제목",
    "content":"앨범 게시글 내용",
    "thumbnailImage" : "thumnail image URL"
}

# DELETE /albumPosts/:id

# PUT /albumPosts/:id
{
    "title": "앨범게시글 제목",
    "content":"앨범 게시글 내용",
    "thumbnailImage" : "thumnail image URL"
}
``` 